### PR TITLE
Add a link to your promo page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ Squeeler
 =========
 
 OS X app to alert you when a process is hogging CPU
+
+http://footle.org/Squeeler/


### PR DESCRIPTION
Because I couldn't find it easily with google when I went to look it back up.
